### PR TITLE
promptForRating must be executed on main application thread 

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -356,7 +356,7 @@ static iRate *sharedInstance = nil;
 	}
 	
 	//prompt user
-	[self promptForRating];
+  [self performSelectorOnMainThread:@selector(promptForRating) withObject:nil waitUntilDone:YES];
 }
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error


### PR DESCRIPTION
one of my apps have some crashes related to iRate. 

The issue is that promptForRating function was executing on a background thread, and because it contains a UIAlert dialog, it caused a crash. My app downloads data on launch, so it switch to use a background thread in order to not lock the UI.

This fix guarantees iRate UIAlert dialog will execute on the application's main thread. 
