### PR TITLE
Check with (&somesymbol != NULL) instead of (&somesymbol)

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -79,7 +79,7 @@ static iRate *sharedInstance = nil;
 													 name:UIApplicationDidFinishLaunchingNotification
 												   object:nil];
 		
-		if (&UIApplicationWillEnterForegroundNotification)
+		if (&UIApplicationWillEnterForegroundNotification != NULL)
 		{
 			[[NSNotificationCenter defaultCenter] addObserver:self
 													 selector:@selector(applicationWillEnterForeground:)


### PR DESCRIPTION
The original form generates a warning in Xcode 4.
