### PR TITLE
App update

### DIFF
--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -101,6 +101,7 @@
 - (void)iRateUserDidAttemptToRateApp;
 - (void)iRateUserDidDeclineToRateApp;
 - (void)iRateUserDidRequestReminderToRateApp;
+- (void)iRateDidDetectAppUpdate;
 
 @end
 

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -422,6 +422,11 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         [defaults setInteger:0 forKey:iRateEventCountKey];
         [defaults setObject:nil forKey:iRateLastRemindedKey];
         [defaults synchronize];
+
+        //inform about app update
+        if ([delegate respondsToSelector:@selector(iRateDidDetectAppUpdate)]) {
+            [delegate iRateDidDetectAppUpdate];
+        }        
     }
     
     [self incrementUseCount];


### PR DESCRIPTION
The delegate may need to know if iRate detected a version change (e.g.: for resetting preferences).
