### PR TITLE
Added `onlyPromptIfMainWindowIsAvailable` to usage settings

### DIFF
--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -133,6 +133,7 @@ extern NSString *const iRateAppStoreGenreGame;
     NSString *rateButtonLabel;
     NSURL *ratingsURL;
     BOOL onlyPromptIfLatestVersion;
+    BOOL onlyPromptIfMainWindowIsAvailable;
     BOOL promptAtLaunch;
     BOOL debug;
     id<iRateDelegate> __AH_WEAK delegate;
@@ -168,6 +169,7 @@ extern NSString *const iRateAppStoreGenreGame;
 
 //debugging and prompt overrides
 @property (nonatomic, assign) BOOL onlyPromptIfLatestVersion;
+@property (nonatomic, assign) BOOL onlyPromptIfMainWindowIsAvailable;
 @property (nonatomic, assign) BOOL promptAtLaunch;
 @property (nonatomic, assign) BOOL debug;
 

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -86,6 +86,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 @synthesize rateButtonLabel;
 @synthesize ratingsURL;
 @synthesize onlyPromptIfLatestVersion;
+@synthesize onlyPromptIfMainWindowIsAvailable;
 @synthesize promptAtLaunch;
 @synthesize debug;
 @synthesize delegate;
@@ -196,6 +197,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         
         //usage settings - these have sensible defaults
         onlyPromptIfLatestVersion = YES;
+        onlyPromptIfMainWindowIsAvailable = YES;
         promptAtLaunch = YES;
         usesUntilPrompt = 10;
         eventsUntilPrompt = 10;
@@ -614,7 +616,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 #else
 
         //only show when main window is available
-        if (![[NSApplication sharedApplication] mainWindow])
+        if (onlyPromptIfMainWindowIsAvailable && ![[NSApplication sharedApplication] mainWindow])
         {
             [self performSelector:@selector(promptForRating) withObject:nil afterDelay:0.5];
             return;


### PR DESCRIPTION
Some apps, such as ones that live in the menubar, end up never having a window.

If set to NO, `onlyPromptIfMainWindowIsAvailable` allows such apps to create an iRate alert unattached to any window.

Set to YES by default.... no change to current default behavior.
