### PR TITLE
Fixed compiler warning in Xcode 4.2

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -488,7 +488,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 - (void)setAppStoreIDOnMainThread:(NSString *)appStoreIDString
 {
-    self.appStoreID = [appStoreIDString longLongValue];
+    self.appStoreID = (NSUInteger)[appStoreIDString longLongValue];
 }
 
 - (void)connectionSucceeded


### PR DESCRIPTION
//Implicit conversion loses integer precision: 'long long' to 'NSUInteger' (aka 'unsigned int')
