### PR TITLE
Removed warning for projects with a minimum SDK of 6.0

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -852,7 +852,11 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 - (void)productViewControllerDidFinish:(SKStoreProductViewController *)controller
 {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
+    [controller.presentingViewController dismissViewControllerAnimated:YES completion:^{}];
+#else
     [controller.presentingViewController dismissModalViewControllerAnimated:YES];
+#endif
 }
 
 - (void)resizeAlertView:(UIAlertView *)alertView


### PR DESCRIPTION
Since dismissModalViewController is now deprecated, I added a #ifdef block around the dismissModalViewController to use the new dismissViewController:animated:completion method
