### PR TITLE
Danish translation of 'it*

### DIFF
--- a/iRate/iRate.bundle/da.lproj/Localizable.strings
+++ b/iRate/iRate.bundle/da.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 "iRateMessageTitle" = "Vurdér %@";
-"iRateAppMessage" = "Hvis du kan lide at bruge %@, vil du ikke tage et øjeblik til at vurdere den? Det tager ikke mere end et minut. Tak for din hjælp!";
-"iRateGameMessage" = "Hvis du kan lide at spille %@, vil du ikke tage et øjeblik til at vurdere den? Det tager ikke mere end et minut. Tak for din hjælp!";
+"iRateAppMessage" = "Hvis du kan lide at bruge %@, vil du ikke tage et øjeblik til at vurdere det? Det tager ikke mere end et minut. Tak for din hjælp!";
+"iRateGameMessage" = "Hvis du kan lide at spille %@, vil du ikke tage et øjeblik til at vurdere det? Det tager ikke mere end et minut. Tak for din hjælp!";
 "iRateCancelButton" = "Nej tak";
 "iRateRateButton" = "Vurdér nu";
 "iRateRemindButton" = "Påmind senere";


### PR DESCRIPTION
I've altered the danish translation of 'it' as I think that 'det' is a better fit than 'den' in this particular situation.
