### PR TITLE
Added delegate method for tracking when prompt gets shown

### DIFF
--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -74,6 +74,12 @@ iRateErrorCode;
 @protocol iRateDelegate <NSObject>
 @optional
 
+/**
+ * Useful if you use event tracking to track what percentage of users see the prompt and then go
+ * to the app store. This can help you fine tune the circumstances around when/how you show the prompt.
+ */
+- (void)iRateDidPromptForRating;
+
 - (void)iRateCouldNotConnectToAppStore:(NSError *)error;
 - (void)iRateDidDetectAppUpdate;
 - (BOOL)iRateShouldPromptForRating;

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -716,7 +716,6 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         
         self.visibleAlert = alert;
         [self.visibleAlert show];
-
 #else
 
         //only show when main window is available
@@ -743,7 +742,11 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                                         contextInfo:nil];
 
 #endif
-        
+
+        // Let delegate know that you prompted for a rating
+        if ([self.delegate respondsToSelector:@selector(iRateDidPromptForRating)]) {
+            [self.delegate iRateDidPromptForRating];
+        }
     }
 }
 


### PR DESCRIPTION
This delegate method is useful if you want to know when the prompt is shown. I use it for building Mixpanel funnels, so I can find out what percentage of people that get shown the prompt actually end up reviewing the app. From there, I can fine tune the settings for when/how the prompt gets shown to get the best chance at getting a good review. Maybe others will find it useful as well.

Thanks iRate, it's really useful!
