### PR TITLE
Fixed podspec

### DIFF
--- a/iRate.podspec
+++ b/iRate.podspec
@@ -6,7 +6,8 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/nicklockwood/iRate'
   s.authors  = 'Nick Lockwood'
   s.source   = { :git => 'https://github.com/nicklockwood/iRate.git', :tag => '1.7.4' }
-  s.source_files = 'iRate'
+  s.source_files = 'iRate/iRate.{h,m}'
+  s.resources    = 'iRate/iRate.bundle'
   s.framework    = 'StoreKit'
   s.requires_arc = true
   s.ios.deployment_target = '4.3'


### PR DESCRIPTION
- added missed punctuation (spec in cocoapod's repo already has it)
- added dependency on StoreKit framework. Version before 1.7.4 in cocoapod's repo have it. I can update cocoapods's spec for the latest version as well.
