### PR TITLE
Added method to trigger prompting if needed

### DIFF
--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -144,6 +144,7 @@ iRateErrorCode;
 //manually control behaviour
 - (BOOL)shouldPromptForRating;
 - (void)promptForRating;
+- (void)promptIfNeeded;
 - (void)promptIfNetworkAvailable;
 - (void)openRatingsPageInAppStore;
 - (void)logEvent:(BOOL)deferPrompt;

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -688,6 +688,14 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     }
 }
 
+- (void)promptIfNeeded
+{
+    if ([self shouldPromptForRating])
+    {
+        [self promptIfNetworkAvailable];
+    }
+}
+
 - (void)promptIfNetworkAvailable
 {
     if (!self.currentlyChecking)
@@ -773,9 +781,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     }
     
     [self incrementUseCount];
-    if (self.promptAtLaunch && [self shouldPromptForRating])
+    if (self.promptAtLaunch)
     {
-        [self promptIfNetworkAvailable];
+        [self promptIfNeeded];
     }
 }
 
@@ -786,9 +794,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground)
     {
         [self incrementUseCount];
-        if (self.promptAtLaunch && [self shouldPromptForRating])
+        if (self.promptAtLaunch)
         {
-            [self promptIfNetworkAvailable];
+            [self promptIfNeeded];
         }
     }
 }
@@ -1111,9 +1119,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 - (void)logEvent:(BOOL)deferPrompt
 {
     [self incrementEventCount];
-    if (!deferPrompt && [self shouldPromptForRating])
+    if (!deferPrompt)
     {
-        [self promptIfNetworkAvailable];
+        [self promptIfNeeded];
     }
 }
 


### PR DESCRIPTION
This change reduces some code duplication and allows to ask outside iRate to prompt the user to rate app if needed.

**Why do we need this.**

We use custom dialog for prompting. In `iRateShouldPromptForRating` we return NO and show our custom dialog. So iRate handles all the logic for us (thanks!).

Also we have a passcode which can be enabled or disabled. We want to prompt the user at launch (`promptAtLaunch` is true). But if the user has enabled the passcode in our app we don't want to ask him to rate the app until he enter passcode. That's why we have something like this:

``` obj-c
#pragma mark - iRateDelegate

- (BOOL)iRateShouldPromptForRating
{
  if (self.presentingPasscodeInput == NO) {
    // show our custom prompt
  }
  return NO;
}
```

And when passcode is unlocked I need to ask iRate to prompt the user to rate the app if needed. 

As one of solutions is when the passcode is unlocked to call:

``` obj-c
if ([[iRate sharedInstance] shouldPromptForRating])
{
     [[iRate sharedInstance] promptIfNetworkAvailable];
}
```

But it doesn't seems very nice to me. I think call `[[iRate sharedInstance] promptIfNeeded]` is cleaner. And it also reduces some code duplication in the library itself.

Thoughts? :)
