### PR TITLE
Warnings fixes

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -781,7 +781,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 
-- (void)applicationWillEnterForeground:(NSNotification *)notification
+- (void)applicationWillEnterForeground:(NSNotification __unused *)notification
 {
     if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground)
     {


### PR DESCRIPTION
This pull request fixes two warnings that are generated when compiling with -Wextra:
1. Semicolon before method body.
2. Unused notification parameter in app delegate.
