### PR TITLE
Adding sender to the protocol methods

### DIFF
--- a/Examples/Advanced Demo/iRateMacAppDelegate.m
+++ b/Examples/Advanced Demo/iRateMacAppDelegate.m
@@ -50,16 +50,16 @@
 #pragma mark -
 #pragma mark iVersionDelegate methods
 
-- (void)iRateCouldNotConnectToAppStore:(NSError *)error
+- (void)iRateCouldNotConnectToAppStore:(iRate*)sender withError :(NSError *)error
 {
 	[label setStringValue:[error localizedDescription]];
 	[progressIndicator stopAnimation:self];
 }
 
-- (BOOL)iRateShouldPromptForRating
+- (BOOL)iRateShouldPromptForRating:(iRate*)sender
 {
 	//don't show prompt, just open app store
-	[[iRate sharedInstance] openRatingsPageInAppStore];
+	[sender openRatingsPageInAppStore];
 	[label setStringValue:@"Connected."];
 	[progressIndicator stopAnimation:self];
 	return NO;

--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -86,7 +86,7 @@ iRateErrorCode;
 - (void)iRateUserDidAttemptToRateApp:(iRate*)sender;
 - (void)iRateUserDidDeclineToRateApp:(iRate*)sender;
 - (void)iRateUserDidRequestReminderToRateApp:(iRate*)sender;
-- (BOOL)iRateShouldOpenAppStore:(id)sender;
+- (BOOL)iRateShouldOpenAppStore:(iRate*)sender;
 - (void)iRateDidPresentStoreKitModal:(iRate*)sender;
 - (void)iRateDidDismissStoreKitModal:(iRate*)sender;
 

--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -74,20 +74,21 @@ typedef enum
 }
 iRateErrorCode;
 
+@class iRate;
 
 @protocol iRateDelegate <NSObject>
 @optional
 
-- (void)iRateCouldNotConnectToAppStore:(NSError *)error;
-- (void)iRateDidDetectAppUpdate;
-- (BOOL)iRateShouldPromptForRating;
-- (void)iRateDidPromptForRating;
-- (void)iRateUserDidAttemptToRateApp;
-- (void)iRateUserDidDeclineToRateApp;
-- (void)iRateUserDidRequestReminderToRateApp;
-- (BOOL)iRateShouldOpenAppStore;
-- (void)iRateDidPresentStoreKitModal;
-- (void)iRateDidDismissStoreKitModal;
+- (void)iRateCouldNotConnectToAppStore:(iRate*)sender withError:(NSError *)error;
+- (void)iRateDidDetectAppUpdate:(iRate*)sender;
+- (BOOL)iRateShouldPromptForRating:(iRate*)sender;
+- (void)iRateDidPromptForRating:(iRate*)sender;
+- (void)iRateUserDidAttemptToRateApp:(iRate*)sender;
+- (void)iRateUserDidDeclineToRateApp:(iRate*)sender;
+- (void)iRateUserDidRequestReminderToRateApp:(iRate*)sender;
+- (BOOL)iRateShouldOpenAppStore:(id)sender;
+- (void)iRateDidPresentStoreKitModal:(iRate*)sender;
+- (void)iRateDidDismissStoreKitModal:(iRate*)sender;
 
 @end
 

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -552,9 +552,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.checkingForPrompt = NO;
         
         //confirm with delegate
-        if ([self.delegate respondsToSelector:@selector(iRateShouldPromptForRating)])
+        if ([self.delegate respondsToSelector:@selector(iRateShouldPromptForRating:)])
         {
-            if (![self.delegate iRateShouldPromptForRating])
+            if (![self.delegate iRateShouldPromptForRating:self])
             {
                 if (self.verboseLogging)
                 {
@@ -585,9 +585,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     }
     
     //could not connect
-    if ([self.delegate respondsToSelector:@selector(iRateCouldNotConnectToAppStore:)])
+    if ([self.delegate respondsToSelector:@selector(iRateCouldNotConnectToAppStore:withError:)])
     {
-        [self.delegate iRateCouldNotConnectToAppStore:error];
+        [self.delegate iRateCouldNotConnectToAppStore:self withError:error];
     }
 }
 
@@ -780,9 +780,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 #endif
 
         //inform about prompt
-        if ([self.delegate respondsToSelector:@selector(iRateDidPromptForRating)])
+        if ([self.delegate respondsToSelector:@selector(iRateDidPromptForRating:)])
         {
-            [self.delegate iRateDidPromptForRating];
+            [self.delegate iRateDidPromptForRating:self];
         }
     }
 }
@@ -802,9 +802,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         [defaults synchronize];
 
         //inform about app update
-        if ([self.delegate respondsToSelector:@selector(iRateDidDetectAppUpdate)])
+        if ([self.delegate respondsToSelector:@selector(iRateDidDetectAppUpdate:)])
         {
-            [self.delegate iRateDidDetectAppUpdate];
+            [self.delegate iRateDidDetectAppUpdate:self];
         }        
     }
     
@@ -870,9 +870,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                 }
                 
                 self.ratedThisVersion = NO;
-                if ([self.delegate respondsToSelector:@selector(iRateCouldNotConnectToAppStore:)])
+                if ([self.delegate respondsToSelector:@selector(iRateCouldNotConnectToAppStore: withError:)])
                 {
-                    [self.delegate iRateCouldNotConnectToAppStore:error];
+                    [self.delegate iRateCouldNotConnectToAppStore:self withError:error];
                 }
             }
         }];
@@ -896,9 +896,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             
             //present product view controller
             [rootViewController presentViewController:productController animated:YES completion:nil];
-            if ([self.delegate respondsToSelector:@selector(iRateDidPresentStoreKitModal)])
+            if ([self.delegate respondsToSelector:@selector(iRateDidPresentStoreKitModal:)])
             {
-                [self.delegate iRateDidPresentStoreKitModal];
+                [self.delegate iRateDidPresentStoreKitModal:self];
             }
             return YES;
         }
@@ -918,9 +918,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 - (void)productViewControllerDidFinish:(UIViewController *)controller
 {
     [controller.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
-    if ([self.delegate respondsToSelector:@selector(iRateDidDismissStoreKitModal)])
+    if ([self.delegate respondsToSelector:@selector(iRateDidDismissStoreKitModal:)])
     {
-        [self.delegate iRateDidDismissStoreKitModal];
+        [self.delegate iRateDidDismissStoreKitModal:self];
     }
 }
 
@@ -1006,9 +1006,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.declinedThisVersion = YES;
         
         //log event
-        if ([self.delegate respondsToSelector:@selector(iRateUserDidDeclineToRateApp)])
+        if ([self.delegate respondsToSelector:@selector(iRateUserDidDeclineToRateApp:)])
         {
-            [self.delegate iRateUserDidDeclineToRateApp];
+            [self.delegate iRateUserDidDeclineToRateApp:self];
         }
     }
     else if (([self.cancelButtonLabel length] && buttonIndex == 2) ||
@@ -1018,9 +1018,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.lastReminded = [NSDate date];
         
         //log event
-        if ([self.delegate respondsToSelector:@selector(iRateUserDidRequestReminderToRateApp)])
+        if ([self.delegate respondsToSelector:@selector(iRateUserDidRequestReminderToRateApp:)])
         {
-            [self.delegate iRateUserDidRequestReminderToRateApp];
+            [self.delegate iRateUserDidRequestReminderToRateApp:self];
         }
     }
     else
@@ -1029,12 +1029,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.ratedThisVersion = YES;
         
         //log event
-        if ([self.delegate respondsToSelector:@selector(iRateUserDidAttemptToRateApp)])
+        if ([self.delegate respondsToSelector:@selector(iRateUserDidAttemptToRateApp:)])
         {
-            [self.delegate iRateUserDidAttemptToRateApp];
+            [self.delegate iRateUserDidAttemptToRateApp:self];
         }
         
-        if (![self.delegate respondsToSelector:@selector(iRateShouldOpenAppStore)] || [_delegate iRateShouldOpenAppStore])
+        if (![self.delegate respondsToSelector:@selector(iRateShouldOpenAppStore:)] || [_delegate iRateShouldOpenAppStore:self])
         {
             //go to ratings page
             [self openRatingsPageInAppStore];
@@ -1100,9 +1100,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             self.declinedThisVersion = YES;
             
             //log event
-            if ([self.delegate respondsToSelector:@selector(iRateUserDidDeclineToRateApp)])
+            if ([self.delegate respondsToSelector:@selector(iRateUserDidDeclineToRateApp:)])
             {
-                [self.delegate iRateUserDidDeclineToRateApp];
+                [self.delegate iRateUserDidDeclineToRateApp:self];
             }
 
             break;
@@ -1113,12 +1113,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             self.ratedThisVersion = YES;
             
             //log event
-            if ([self.delegate respondsToSelector:@selector(iRateUserDidAttemptToRateApp)])
+            if ([self.delegate respondsToSelector:@selector(iRateUserDidAttemptToRateApp:)])
             {
-                [self.delegate iRateUserDidAttemptToRateApp];
+                [self.delegate iRateUserDidAttemptToRateApp:self];
             }
             
-            if (![self.delegate respondsToSelector:@selector(iRateShouldOpenAppStore)] || [_delegate iRateShouldOpenAppStore])
+            if (![self.delegate respondsToSelector:@selector(iRateShouldOpenAppStore:)] || [_delegate iRateShouldOpenAppStore:self])
             {
                 //launch mac app store
                 [self openRatingsPageInAppStore];
@@ -1131,9 +1131,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             self.lastReminded = [NSDate date];
             
             //log event
-            if ([self.delegate respondsToSelector:@selector(iRateUserDidRequestReminderToRateApp)])
+            if ([self.delegate respondsToSelector:@selector(iRateUserDidRequestReminderToRateApp:)])
             {
-                [self.delegate iRateUserDidRequestReminderToRateApp];
+                [self.delegate iRateUserDidRequestReminderToRateApp:self];
             }
         }
     }


### PR DESCRIPTION
The current implementation of iRate does not provide the source in the protocol methods.  

It is typical for delegation messages to contain the source.  See this section on apple's docs.

https://developer.apple.com/library/ios/documentation/general/conceptual/CocoaEncyclopedia/DelegatesandDataSources/DelegatesandDataSources.html#//apple_ref/doc/uid/TP40010810-CH11-SW3

When binding the iRate library to other languages that expect this argument, incorrect assumptions are made and the API appears broken.
