### PR TITLE
Don't interrupt rating popups for the period of "daysUntilPrompt" on app update

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -829,12 +829,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     if (![[defaults objectForKey:iRateLastVersionUsedKey] isEqualToString:self.applicationVersion])
     {
-        //reset counts
         [defaults setObject:self.applicationVersion forKey:iRateLastVersionUsedKey];
-        [defaults setObject:[NSDate date] forKey:iRateFirstUsedKey];
-        [defaults setInteger:0 forKey:iRateUseCountKey];
-        [defaults setInteger:0 forKey:iRateEventCountKey];
-        [defaults setObject:nil forKey:iRateLastRemindedKey];
+        if ([[NSDate date] timeIntervalSinceDate:self.firstUsed] >= self.daysUntilPrompt * SECONDS_IN_A_DAY) {
+            //ask for rating one day later
+            NSDate *oneDayDelay = [NSDate dateWithTimeIntervalSinceNow:(self.daysUntilPrompt-1) * (-SECONDS_IN_A_DAY)];
+            [defaults setObject:oneDayDelay forKey:iRateFirstUsedKey];
+        }
         [defaults synchronize];
 
         //inform about app update


### PR DESCRIPTION
When updating my app, this is what I'm seeing:

![graph](https://f.cloud.github.com/assets/713965/2241324/263b8a62-9ccb-11e3-9924-53fe17763b12.png)

The graph shows the number of iRate popups per day. When app update happens, iRate resets all counters so for 10 days there are no iRate popups which reduces sales and the position in the top lists. Even afterwards the number of popups isn't at its peak because for people who don't update the first day, the 10 day period starts later. 

Also some popups are just "lost" because if someone was at day 9 of using the app and performed the update, the period is extended by another 10 days which makes it effectively 19 days of daysUntilPrompt and if the user doesn't use the app frequently enough, there aren't enough events to trigger the popup.

Personally I don't completely understand the reasoning behind zeroing the counters. If the user used the app for long enough I don't think he needs 10 extra days to notice the possible bug fix in the updated version. 

The patch gives one day to the user to see the improvements in the new version of the app before the popup appears in the case it's time for rating. Otherwise it just keeps using the existing counters without zeroing them. I haven't really tested the patch but I hope it's doing what it's supposed to.
