### PR TITLE
Fixed issue with preview mode when promptAtLaunch is set to NO

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -843,7 +843,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     
     [self incrementUseCount];
     [self checkForConnectivityInBackground];
-    if (self.promptAtLaunch && [self shouldPromptForRating])
+    if (self.previewMode || (self.promptAtLaunch && [self shouldPromptForRating]))
     {
         [self promptIfNetworkAvailable];
     }


### PR DESCRIPTION
iRate was not displayed on previewMode enabled when promptAtLaunch = NO
