### PR TITLE
Initialize counters when app started for the very first time

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -865,9 +865,17 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     if (![[defaults objectForKey:iRateLastVersionUsedKey] isEqualToString:self.applicationVersion])
     {
         [defaults setObject:self.applicationVersion forKey:iRateLastVersionUsedKey];
-        if ([[NSDate date] timeIntervalSinceDate:self.firstUsed] >= self.daysUntilPrompt * SECONDS_IN_A_DAY)
+        if (self.firstUsed == nil) {
+            //first use - reset counts
+            [defaults setObject:self.applicationVersion forKey:iRateLastVersionUsedKey];
+            [defaults setObject:[NSDate date] forKey:iRateFirstUsedKey];
+            [defaults setInteger:0 forKey:iRateUseCountKey];
+            [defaults setInteger:0 forKey:iRateEventCountKey];
+            [defaults setObject:nil forKey:iRateLastRemindedKey];
+        }
+        else if ([[NSDate date] timeIntervalSinceDate:self.firstUsed] >= self.daysUntilPrompt * SECONDS_IN_A_DAY)
         {
-            //ask for rating one day later
+            //update - ask for rating one day later if it's time to rate now
             NSDate *oneDayDelay = [NSDate dateWithTimeIntervalSinceNow:(self.daysUntilPrompt-1) * (-SECONDS_IN_A_DAY)];
             [defaults setObject:oneDayDelay forKey:iRateFirstUsedKey];
         }


### PR DESCRIPTION
My previous attempt not to zero couters on update doesn't take into account the case when app is launched for the very first time - counters aren't set in this case, see

https://github.com/nicklockwood/iRate/commit/beb6898b89b865e967a27bc66e1af5952deebd05#commitcomment-5917963

This should fix it (again, untested, so please check before I introduce more issues).

I'm afraid this is a big enough problem that a new release should be made.
