### PR TITLE
Don't connect the Internet every time app starts or enters foreground

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -882,7 +882,6 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     }
     
     [self incrementUseCount];
-    [self checkForConnectivityInBackground];
     if (self.promptAtLaunch && [self shouldPromptForRating])
     {
         [self promptIfNetworkAvailable];
@@ -896,7 +895,6 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground)
     {
         [self incrementUseCount];
-        [self checkForConnectivityInBackground];
         if (self.promptAtLaunch && [self shouldPromptForRating])
         {
             [self promptIfNetworkAvailable];


### PR DESCRIPTION
My app

https://itunes.apple.com/us/app/system-status-activity-monitor/id401457165?mt=8

shows the list of active network connections as one of its features. I've noticed that recently lots of connections started appearing after the app starts. It turns out iRate connects the internet every time the app is started or enters foreground.

After git blame, I got to this commit:

Updated to version 1.8.1
d3bc941b777f1a433c0ef5c24bff7322b33965fb

which contains quite a lot of changes but from the release notes, only this item seems to be relevant:
- Calling openRatingsPageInAppStore will now look up appStoreID automatically if not already known

In my opinion the connectivity check shouldn't be there because it's checked in promptIfNetworkAvailable three lines after but only when needed. But take this as a patch from a guy who doesn't know what he's doing and maybe it breaks other things. Please check.
