### PR TITLE
Return BOOL value for BOOL method instead of integer

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -383,7 +383,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 - (BOOL)declinedAnyVersion
 {
-    return [(NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:iRateDeclinedVersionKey] length];
+    return [(NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:iRateDeclinedVersionKey] length] != 0;
 }
 
 - (BOOL)ratedVersion:(NSString *)version
@@ -404,7 +404,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 - (BOOL)ratedAnyVersion
 {
-    return [(NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:iRateRatedVersionKey] length];
+    return [(NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:iRateRatedVersionKey] length] != 0;
 }
 
 - (void)dealloc


### PR DESCRIPTION
When you return an integer from a BOOL method, strange stuff can happen - especially with regards to comparison to `YES`.

For example:

```
-(BOOL)arrayHasStuff{
    return self.myArray.count;
}
```

If `myArray` has 3 items, this code will behave unexpectedly:

```
if([someClass arrayHasStuff] == YES) {
    // this won't get called because 3 != YES
}
```

Even though the method is declared as BOOL, the Objective-C runtime will still return the integer value. This can cause problems in other ways - for example, if you compare the return value of two BOOL methods, despite both being non-zero the comparison fails - [here's an example of this](https://gist.github.com/dataxpress/479c72bee9a837d039f0). 

Anyway, hope this helps! Love this library & keep up the great work!
