### PR TITLE
Updated the wording for the French localization

### DIFF
--- a/iRate/iRate.bundle/fr.lproj/Localizable.strings
+++ b/iRate/iRate.bundle/fr.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-"iRateMessageTitle" = "Votez %@";
-"iRateAppMessage" = "Si vous aimez utiliser %@, n'oubliez pas de voter sur l'App Store. Cela ne prend qu'une minute. Merci d'avance pour votre soutien !";
-"iRateGameMessage" = "Si vous aimez jouer à %@, n'oubliez pas de voter sur l'App Store. Cela ne prend qu'une minute. Merci d'avance pour votre soutien !";
+"iRateMessageTitle" = "Notez %@";
+"iRateAppMessage" = "Si vous aimez utiliser %@, n'oubliez pas de donner votre avis sur l'App Store. Cela ne prend qu'une minute. Merci d'avance pour votre soutien !";
+"iRateGameMessage" = "Si vous aimez jouer à %@, n'oubliez pas de donner votre avis sur l'App Store. Cela ne prend qu'une minute. Merci d'avance pour votre soutien !";
 "iRateCancelButton" = "Non, merci";
-"iRateRateButton" = "Votez maintenant";
+"iRateRateButton" = "Noter maintenant";
 "iRateRemindButton" = "Me le rappeler ultérieurement";


### PR DESCRIPTION
![french-app-store](https://cloud.githubusercontent.com/assets/1019457/4386393/fe3310e2-43cf-11e4-9290-7a230c547f6f.png)
Now the wording is the same as in the French App Store:
- "Rate" is translated to "Note"
- "Review" is translated to "Avis"

Note that the wording of the title was quite strange. "Votez %@" is
the wording one would use if someone is running for president.
