### PR TITLE
`sharedInstance` should return `instancetype` to ease subclassing.

### DIFF
--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -104,7 +104,7 @@ typedef NS_ENUM(NSUInteger, iRateErrorCode)
 
 @interface iRate : NSObject
 
-+ (iRate *)sharedInstance;
++ (instancetype)sharedInstance;
 
 //app store ID - this is only needed if your
 //bundle ID is not unique between iOS and Mac app stores

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -126,12 +126,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     [self performSelectorOnMainThread:@selector(sharedInstance) withObject:nil waitUntilDone:NO];
 }
 
-+ (iRate *)sharedInstance
++ (instancetype)sharedInstance
 {
     static iRate *sharedInstance = nil;
     if (sharedInstance == nil)
     {
-        sharedInstance = [[iRate alloc] init];
+        sharedInstance = [[self alloc] init];
     }
     return sharedInstance;
 }


### PR DESCRIPTION
Hey,

to ease customization via inheritance of iRate class `+ (iRate *)sharedInstance` method should look like `+ (instancetype)sharedInstance`.

In addition when creating singleton object you should call for `sharedInstance = [[self alloc] init]` instead calling class name directly.

Cheers,
OG