### PR TITLE
update ratingsUrl to link directly to 'reviews' tab.

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -84,7 +84,7 @@ static NSString *const iRateMacAppStoreBundleID = @"com.apple.appstore";
 static NSString *const iRateAppLookupURLFormat = @"http://itunes.apple.com/%@/lookup";
 
 static NSString *const iRateiOSAppStoreURLScheme = @"itms-apps";
-static NSString *const iRateiOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@";
+static NSString *const iRateiOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@&pageNumber=0&sortOrdering=2&mt=8";
 static NSString *const iRateiOS7AppStoreURLFormat = @"itms-apps://itunes.apple.com/app/id%@";
 static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.com/app/id%@";
 
@@ -165,9 +165,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 {
     if ((self = [super init]))
     {
-        
+
 #if TARGET_OS_IPHONE
-        
+
         //register for iphone application events
         if (&UIApplicationWillEnterForegroundNotification)
         {
@@ -176,9 +176,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                                                          name:UIApplicationWillEnterForegroundNotification
                                                        object:nil];
         }
-        
+
 #endif
-        
+
         //get country
         self.appStoreCountry = [(NSLocale *)[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
         if ([self.appStoreCountry isEqualToString:@"150"])
@@ -189,24 +189,24 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         {
             self.appStoreCountry = @"us";
         }
-        
+
         //application version (use short version preferentially)
         self.applicationVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         if ([self.applicationVersion length] == 0)
         {
             self.applicationVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
         }
-        
+
         //localised application name
         self.applicationName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
         if ([self.applicationName length] == 0)
         {
             self.applicationName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey];
         }
-        
+
         //bundle id
         self.applicationBundleID = [[NSBundle mainBundle] bundleIdentifier];
-        
+
         //default settings
         self.useAllAvailableLanguages = YES;
         self.promptForNewVersionIfUserRated = NO;
@@ -220,15 +220,15 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.remindPeriod = 1.0f;
         self.verboseLogging = NO;
         self.previewMode = NO;
-        
+
 #if DEBUG
-        
+
         //enable verbose logging in debug mode
         self.verboseLogging = YES;
         NSLog(@"iRate verbose logging enabled.");
-        
+
 #endif
-        
+
         //app launched
         [self performSelectorOnMainThread:@selector(applicationLaunched) withObject:nil waitUntilDone:NO];
     }
@@ -239,13 +239,13 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 {
     if (_delegate == nil)
     {
-        
+
 #if TARGET_OS_IPHONE
-#define APP_CLASS UIApplication      
+#define APP_CLASS UIApplication
 #else
-#define APP_CLASS NSApplication  
+#define APP_CLASS NSApplication
 #endif
-        
+
         _delegate = (id<iRateDelegate>)[[APP_CLASS sharedApplication] delegate];
     }
     return _delegate;
@@ -297,16 +297,16 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     {
         return _ratingsURL;
     }
-    
+
     if (!self.appStoreID && self.verboseLogging)
     {
         NSLog(@"iRate could not find the App Store ID for this application. If the application is not intended for App Store release then you must specify a custom ratingsURL.");
     }
-    
+
     NSString *URLString;
-    
+
 #if TARGET_OS_IPHONE
-    
+
     float iOSVersion = [[UIDevice currentDevice].systemVersion floatValue];
     if (iOSVersion >= 7.0f && iOSVersion < 7.1f)
     {
@@ -316,15 +316,15 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     {
         URLString = iRateiOSAppStoreURLFormat;
     }
-    
+
 #else
-    
+
     URLString = iRateMacAppStoreURLFormat;
-    
+
 #endif
-            
+
     return [NSURL URLWithString:[NSString stringWithFormat:URLString, @(self.appStoreID)]];
-    
+
 }
 
 - (NSUInteger)appStoreID
@@ -434,14 +434,14 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 }
 
 - (BOOL)shouldPromptForRating
-{   
+{
     //preview mode?
     if (self.previewMode)
     {
         NSLog(@"iRate preview mode is enabled - make sure you disable this for release");
         return YES;
     }
-    
+
     //check if we've rated this version
     else if (self.ratedThisVersion)
     {
@@ -451,7 +451,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return NO;
     }
-    
+
     //check if we've rated any version
     else if (self.ratedAnyVersion && !self.promptForNewVersionIfUserRated)
     {
@@ -461,7 +461,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return NO;
     }
-    
+
     //check if we've declined to rate the app
     else if (self.declinedAnyVersion)
     {
@@ -471,7 +471,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return NO;
     }
-    
+
     //check how long we've been using this version
     else if ([[NSDate date] timeIntervalSinceDate:self.firstUsed] < self.daysUntilPrompt * SECONDS_IN_A_DAY)
     {
@@ -481,7 +481,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return NO;
     }
-    
+
     //check how many times we've used it and the number of significant events
     else if (self.usesCount < self.usesUntilPrompt && self.eventCount < self.eventsUntilPrompt)
     {
@@ -491,7 +491,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return NO;
     }
-    
+
     //check if usage frequency is high enough
     else if (self.usesPerWeek < self.usesPerWeekForPrompt)
     {
@@ -511,7 +511,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return NO;
     }
-    
+
     //lets prompt!
     return YES;
 }
@@ -545,7 +545,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                         value = [json substringWithRange:NSMakeRange(start, valueEnd.location - start)];
                         value = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                     }
-                    
+
                     value = [value stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"\""]];
                     value = [value stringByReplacingOccurrencesOfString:@"\\\\" withString:@"\\"];
                     value = [value stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
@@ -555,7 +555,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                     value = [value stringByReplacingOccurrencesOfString:@"\\t" withString:@"\t"];
                     value = [value stringByReplacingOccurrencesOfString:@"\\f" withString:@"\f"];
                     value = [value stringByReplacingOccurrencesOfString:@"\\b" withString:@"\f"];
-                    
+
                     while (YES)
                     {
                         NSRange unicode = [value rangeOfString:@"\\u"];
@@ -563,12 +563,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                         {
                             break;
                         }
-                        
+
                         uint32_t c = 0;
                         NSString *hex = [value substringWithRange:NSMakeRange(unicode.location + 2, 4)];
                         NSScanner *scanner = [NSScanner scannerWithString:hex];
                         [scanner scanHexInt:&c];
-                        
+
                         if (c <= 0xffff)
                         {
                             value = [value stringByReplacingCharactersInRange:NSMakeRange(unicode.location, 6) withString:[NSString stringWithFormat:@"%C", (unichar)c]];
@@ -581,7 +581,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                             uint16_t w = (uint16_t)u - 1;
                             unichar high = 0xd800 | (w << 6) | x >> 10;
                             unichar low = (uint16_t)(0xdc00 | (x & ((1 << 10) - 1)));
-                            
+
                             value = [value stringByReplacingCharactersInRange:NSMakeRange(unicode.location, 6) withString:[NSString stringWithFormat:@"%C%C", high, low]];
                         }
                     }
@@ -611,7 +611,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         //no longer checking
         self.checkingForPrompt = NO;
         self.checkingForAppStoreID = NO;
-        
+
         //open app store
         [self openRatingsPageInAppStore];
     }
@@ -619,7 +619,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     {
         //no longer checking
         self.checkingForPrompt = NO;
-        
+
         //confirm with delegate
         if (![self.delegate iRateShouldPromptForRating])
         {
@@ -629,7 +629,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             }
             return;
         }
-        
+
         //prompt user
         [self promptForRating];
     }
@@ -642,7 +642,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         //no longer checking
         self.checkingForPrompt = NO;
         self.checkingForAppStoreID = NO;
-        
+
         //log the error
         if (error)
         {
@@ -652,7 +652,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         {
             NSLog(@"iRate rating process failed because an unknown error occured");
         }
-        
+
         //could not connect
         [self.delegate iRateCouldNotConnectToAppStore:error];
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateCouldNotConnectToAppStore
@@ -667,30 +667,30 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         [self performSelectorInBackground:@selector(checkForConnectivityInBackground) withObject:nil];
         return;
     }
-    
+
     @autoreleasepool
     {
         //prevent concurrent checks
         static BOOL checking = NO;
         if (checking) return;
         checking = YES;
-        
+
         //first check iTunes
         NSString *iTunesServiceURL = [NSString stringWithFormat:iRateAppLookupURLFormat, self.appStoreCountry];
         if (_appStoreID) //important that we check ivar and not getter in case it has changed
         {
             iTunesServiceURL = [iTunesServiceURL stringByAppendingFormat:@"?id=%@", @(_appStoreID)];
         }
-        else 
+        else
         {
             iTunesServiceURL = [iTunesServiceURL stringByAppendingFormat:@"?bundleId=%@", self.applicationBundleID];
         }
-        
+
         if (self.verboseLogging)
         {
             NSLog(@"iRate is checking %@ to retrieve the App Store details...", iTunesServiceURL);
         }
-        
+
         NSError *error = nil;
         NSURLResponse *response = nil;
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:iTunesServiceURL] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:REQUEST_TIMEOUT];
@@ -700,7 +700,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         {
             //in case error is garbage...
             error = nil;
-            
+
             id json = nil;
             if ([NSJSONSerialization class])
             {
@@ -711,7 +711,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                 //convert to string
                 json = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
             }
-            
+
             if (!error)
             {
                 //check bundle ID matches
@@ -725,19 +725,19 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                         {
                             self.appStoreGenreID = [[self valueForKey:@"primaryGenreId" inJSON:json] integerValue];
                         }
-                        
+
                         //get app id
                         if (!_appStoreID)
                         {
                             NSString *appStoreIDString = [self valueForKey:@"trackId" inJSON:json];
                             [self performSelectorOnMainThread:@selector(setAppStoreIDOnMainThread:) withObject:appStoreIDString waitUntilDone:YES];
-                            
+
                             if (self.verboseLogging)
                             {
                                 NSLog(@"iRate found the app on iTunes. The App Store ID is %@", appStoreIDString);
                             }
                         }
-                        
+
                         //check version
                         if (self.onlyPromptIfLatestVersion && !self.previewMode)
                         {
@@ -748,7 +748,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                                 {
                                     NSLog(@"iRate found that the installed application version (%@) is not the latest version on the App Store, which is %@", self.applicationVersion, latestVersion);
                                 }
-                                
+
                                 error = [NSError errorWithDomain:iRateErrorDomain code:iRateErrorApplicationIsNotLatestVersion userInfo:@{NSLocalizedDescriptionKey: @"Installed app is not the latest version available"}];
                             }
                         }
@@ -759,7 +759,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                         {
                             NSLog(@"iRate found that the application bundle ID (%@) does not match the bundle ID of the app found on iTunes (%@) with the specified App Store ID (%@)", self.applicationBundleID, bundleID, @(self.appStoreID));
                         }
-                        
+
                         error = [NSError errorWithDomain:iRateErrorDomain code:iRateErrorBundleIdDoesNotMatchAppStore userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Application bundle ID does not match expected value of %@", bundleID]}];
                     }
                 }
@@ -788,7 +788,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             NSString *message = [NSString stringWithFormat:@"The server returned a %@ error", @(statusCode)];
             error = [NSError errorWithDomain:@"HTTPResponseErrorDomain" code:statusCode userInfo:@{NSLocalizedDescriptionKey: message}];
         }
-        
+
         //handle errors (ignoring sandbox issues)
         if (error && !(error.code == EPERM && [error.domain isEqualToString:NSPOSIXErrorDomain] && _appStoreID))
         {
@@ -799,7 +799,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             //show prompt
             [self performSelectorOnMainThread:@selector(connectionSucceeded) withObject:nil waitUntilDone:YES];
         }
-        
+
         //finished
         checking = NO;
     }
@@ -837,24 +837,24 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     if (!self.visibleAlert)
     {
         NSString *message = self.ratedAnyVersion? self.updateMessage: self.message;
-    
+
 #if TARGET_OS_IPHONE
-        
+
         UIViewController *topController = [UIApplication sharedApplication].delegate.window.rootViewController;
         while (topController.presentedViewController)
         {
             topController = topController.presentedViewController;
         }
-        
+
         if ([UIAlertController class] && topController && self.useUIAlertControllerIfAvailable)
         {
             UIAlertController *alert = [UIAlertController alertControllerWithTitle:self.messageTitle message:message preferredStyle:UIAlertControllerStyleAlert];
-            
+
             //rate action
             [alert addAction:[UIAlertAction actionWithTitle:self.rateButtonLabel style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
                 [self didDismissAlert:alert withButtonAtIndex:0];
             }]];
-            
+
             //cancel action
             if ([self showCancelButton])
             {
@@ -862,7 +862,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                     [self didDismissAlert:alert withButtonAtIndex:1];
                 }]];
             }
-            
+
             //remind action
             if ([self showRemindButton])
             {
@@ -870,9 +870,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                     [self didDismissAlert:alert withButtonAtIndex:[self showCancelButton]? 2: 1];
                 }]];
             }
-            
+
             self.visibleAlert = alert;
-            
+
             //get current view controller and present alert
             [topController presentViewController:alert animated:YES completion:NULL];
         }
@@ -888,16 +888,16 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                 [alert addButtonWithTitle:self.cancelButtonLabel];
                 alert.cancelButtonIndex = 1;
             }
-            
+
             if ([self showRemindButton])
             {
                 [alert addButtonWithTitle:self.remindButtonLabel];
             }
-            
+
             self.visibleAlert = alert;
             [self.visibleAlert show];
         }
-        
+
 #else
 
         //only show when main window is available
@@ -919,11 +919,11 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         {
             [alert addButtonWithTitle:self.remindButtonLabel];
         }
-        
+
         self.visibleAlert = alert;
-        
+
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_9
-        
+
         if (![alert respondsToSelector:@selector(beginSheetModalForWindow:completionHandler:)])
         {
             [alert beginSheetModalForWindow:[NSApplication sharedApplication].mainWindow
@@ -932,9 +932,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                                 contextInfo:nil];
         }
         else
-        
+
 #endif
-        
+
         {
             [alert beginSheetModalForWindow:[NSApplication sharedApplication].mainWindow completionHandler:^(NSModalResponse returnCode) {
                 [self didDismissAlert:alert withButtonAtIndex:returnCode - NSAlertFirstButtonReturn];
@@ -979,7 +979,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateDidDetectAppUpdate
                                                             object:nil];
     }
-    
+
     [self incrementUseCount];
     [self checkForConnectivityInBackground];
     if (self.promptAtLaunch)
@@ -994,7 +994,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     NSInteger rateButtonIndex = 0;
     NSInteger cancelButtonIndex = [self showCancelButton]? 1: 0;
     NSInteger remindButtonIndex = [self showRemindButton]? cancelButtonIndex + 1: 0;
-    
+
     if (buttonIndex == rateButtonIndex)
     {
         [self rate];
@@ -1007,7 +1007,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     {
         [self remindLater];
     }
-    
+
     //release alert
     self.visibleAlert = nil;
 }
@@ -1038,14 +1038,14 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return;
     }
-    
+
     if ([[UIApplication sharedApplication] canOpenURL:self.ratingsURL])
     {
         if (self.verboseLogging)
         {
             NSLog(@"iRate will open the App Store ratings page using the following URL: %@", self.ratingsURL);
         }
-        
+
         [[UIApplication sharedApplication] openURL:self.ratingsURL];
         [self.delegate iRateDidOpenAppStore];
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateDidOpenAppStore
@@ -1054,14 +1054,14 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     else
     {
          NSString *message = [NSString stringWithFormat:@"iRate was unable to open the specified ratings URL: %@", self.ratingsURL];
-        
+
 #if TARGET_IPHONE_SIMULATOR
-        
+
         if ([[self.ratingsURL scheme] isEqualToString:iRateiOSAppStoreURLScheme])
         {
             message = @"iRate could not open the ratings page because the App Store is not available on the iOS simulator";
         }
-        
+
 #endif
         NSLog(@"%@", message);
         NSError *error = [NSError errorWithDomain:iRateErrorDomain code:iRateErrorCouldNotOpenRatingPageURL userInfo:@{NSLocalizedDescriptionKey: message}];
@@ -1090,7 +1090,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             return;
         }
     }
-    
+
     //try again
     [self performSelector:@selector(openAppPageWhenAppStoreLaunched) withObject:nil afterDelay:0.0];
 }
@@ -1106,12 +1106,12 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         return;
     }
-    
+
     if (self.verboseLogging)
     {
         NSLog(@"iRate will open the App Store ratings page using the following URL: %@", self.ratingsURL);
     }
-    
+
     [[NSWorkspace sharedWorkspace] openURL:self.ratingsURL];
     [self openAppPageWhenAppStoreLaunched];
     [self.delegate iRateDidOpenAppStore];


### PR DESCRIPTION
This seems like a good default behavior.  I've tested this in iOS 8.1 and it seems to work just fine.