### PR TITLE
use `US` as the default country code value

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -188,6 +188,8 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         else if ([[self.appStoreCountry stringByReplacingOccurrencesOfString:@"[A-Za-z]{2}" withString:@"" options:NSRegularExpressionSearch range:NSMakeRange(0, 2)] length])
         {
             self.appStoreCountry = @"us";
+        } else if (self.appStoreCountry == nil) {
+            self.appStoreCountry = @"us";
         }
         
         //application version (use short version preferentially)


### PR DESCRIPTION
In some cases, `NSLocale` will contain `null` as the country code. This cause the itunes lookup to fail, as the url contains (null) instead of the county code.  (Happened to me in debug mode when `Application Language` is set manually from the manage schema)

This change adds the `us` as the default country in case no value could be detected.

also might be related to #144. I can assume some locales dont have a specific country code
