### PR TITLE
The iRate now searches for the localization files in a proper folder.

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -141,7 +141,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     static NSBundle *bundle = nil;
     if (bundle == nil)
     {
-        NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"iRate" ofType:@"bundle"];
+        NSString *bundlePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"iRate" ofType:@"bundle"];
         if (self.useAllAvailableLanguages)
         {
             bundle = [NSBundle bundleWithPath:bundlePath];


### PR DESCRIPTION
I've faced an issue: if I use the iRate within a custom framework, I'm unable to get the UI part properly localized (it's always in English) due to the iRate.bundle doesn't appear to be within the main app bundle. To overcome the described issue, I'd recommend replacing ```[NSBundle mainBundle]``` with ``` [NSBundle bundleForClass:[self class]]``` (for details please see the attached commit).