### PR TITLE
Use an HTTPS connection to itunes.apple.com

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -81,7 +81,7 @@ static NSString *const iRateUseCountKey = @"iRateUseCount";
 static NSString *const iRateEventCountKey = @"iRateEventCount";
 
 static NSString *const iRateMacAppStoreBundleID = @"com.apple.appstore";
-static NSString *const iRateAppLookupURLFormat = @"http://itunes.apple.com/%@/lookup";
+static NSString *const iRateAppLookupURLFormat = @"https://itunes.apple.com/%@/lookup";
 
 static NSString *const iRateiOSAppStoreURLScheme = @"itms-apps";
 static NSString *const iRateiOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@&pageNumber=0&sortOrdering=2&mt=8";


### PR DESCRIPTION
Not only is this more secure (and plays more nicely with App Transport
Security), but http://itunes.apple.com canonically redirects to the https://
version anyway.