### PR TITLE
disable making network requests on load

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -121,11 +121,6 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 @implementation iRate
 
-+ (void)load
-{
-    [self performSelectorOnMainThread:@selector(sharedInstance) withObject:nil waitUntilDone:NO];
-}
-
 + (instancetype)sharedInstance
 {
     static iRate *sharedInstance = nil;


### PR DESCRIPTION
fixes https://github.com/nicklockwood/iRate/issues/224

To start iRate add
```[iRate sharedInstance];```
within
```- application:didFinishLaunchingWithOptions:```
or in other appropriate method

This is the same change as https://github.com/nicklockwood/iRate/pull/197, just using latest iRate