### PR TITLE
Use standard implementation for optional delegate methods

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -95,21 +95,6 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 #define REQUEST_TIMEOUT 60.0
 
 
-@implementation NSObject (iRate)
-
-- (void)iRateCouldNotConnectToAppStore:(__unused NSError *)error {}
-- (void)iRateDidDetectAppUpdate {}
-- (BOOL)iRateShouldPromptForRating { return YES; }
-- (void)iRateDidPromptForRating {}
-- (void)iRateUserDidAttemptToRateApp {}
-- (void)iRateUserDidDeclineToRateApp {}
-- (void)iRateUserDidRequestReminderToRateApp {}
-- (BOOL)iRateShouldOpenAppStore { return YES; }
-- (void)iRateDidOpenAppStore {}
-
-@end
-
-
 @interface iRate()
 
 @property (nonatomic, strong) id visibleAlert;
@@ -621,7 +606,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.checkingForPrompt = NO;
 
         //confirm with delegate
-        if (![self.delegate iRateShouldPromptForRating])
+        if ([self.delegate respondsToSelector:@selector(iRateShouldPromptForRating)] && ![self.delegate iRateShouldPromptForRating])
         {
             if (self.verboseLogging)
             {
@@ -654,7 +639,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
 
         //could not connect
-        [self.delegate iRateCouldNotConnectToAppStore:error];
+        if ([self.delegate respondsToSelector:@selector(iRateCouldNotConnectToAppStore:)]) {
+            [self.delegate iRateCouldNotConnectToAppStore:error];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateCouldNotConnectToAppStore
                                                             object:error];
     }
@@ -945,7 +932,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 #endif
 
         //inform about prompt
-        [self.delegate iRateDidPromptForRating];
+        if ([self.delegate respondsToSelector:@selector(iRateDidPromptForRating)]) {
+            [self.delegate iRateDidPromptForRating];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateDidPromptForRating
                                                             object:nil];
     }
@@ -976,7 +965,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
 
         //inform about app update
-        [self.delegate iRateDidDetectAppUpdate];
+        if ([self.delegate respondsToSelector:@selector(iRateDidDetectAppUpdate)]) {
+            [self.delegate iRateDidDetectAppUpdate];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateDidDetectAppUpdate
                                                             object:nil];
     }
@@ -1062,7 +1053,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     {
         NSLog(@"%@", cantOpenMessage);
         NSError *error = [NSError errorWithDomain:iRateErrorDomain code:iRateErrorCouldNotOpenRatingPageURL userInfo:@{NSLocalizedDescriptionKey: cantOpenMessage}];
-        [self.delegate iRateCouldNotConnectToAppStore:error];
+        if ([self.delegate respondsToSelector:@selector(iRateCouldNotConnectToAppStore:)]) {
+            [self.delegate iRateCouldNotConnectToAppStore:error];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateCouldNotConnectToAppStore
                                                             object:error];
     }
@@ -1074,7 +1067,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
 
         [[UIApplication sharedApplication] openURL:self.ratingsURL];
-        [self.delegate iRateDidOpenAppStore];
+        if ([self.delegate respondsToSelector:@selector(iRateDidOpenAppStore)]) {
+            [self.delegate iRateDidOpenAppStore];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:iRateDidOpenAppStore
                                                         object:nil];
     }
@@ -1123,7 +1118,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
     [[NSWorkspace sharedWorkspace] openURL:self.ratingsURL];
     [self openAppPageWhenAppStoreLaunched];
-    [self.delegate iRateDidOpenAppStore];
+    if ([self.delegate respondsToSelector:@selector(iRateDidOpenAppStore)]) {
+        [self.delegate iRateDidOpenAppStore];
+    }
 }
 
 - (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(__unused void *)contextInfo
@@ -1150,7 +1147,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     self.declinedThisVersion = YES;
 
     //log event
-    [self.delegate iRateUserDidDeclineToRateApp];
+    if ([self.delegate respondsToSelector:@selector(iRateUserDidDeclineToRateApp)]) {
+        [self.delegate iRateUserDidDeclineToRateApp];
+    }
     [[NSNotificationCenter defaultCenter] postNotificationName:iRateUserDidDeclineToRateApp
                                                         object:nil];
 }
@@ -1161,7 +1160,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     self.lastReminded = [NSDate date];
 
     //log event
-    [self.delegate iRateUserDidRequestReminderToRateApp];
+    if ([self.delegate respondsToSelector:@selector(iRateUserDidRequestReminderToRateApp)]) {
+        [self.delegate iRateUserDidRequestReminderToRateApp];
+    }
     [[NSNotificationCenter defaultCenter] postNotificationName:iRateUserDidRequestReminderToRateApp
                                                         object:nil];
 }
@@ -1172,11 +1173,14 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
     self.ratedThisVersion = YES;
 
     //log event
-    [self.delegate iRateUserDidAttemptToRateApp];
+    if ([self.delegate respondsToSelector:@selector(iRateUserDidAttemptToRateApp)]) {
+        [self.delegate iRateUserDidAttemptToRateApp];
+    }
     [[NSNotificationCenter defaultCenter] postNotificationName:iRateUserDidAttemptToRateApp
                                                         object:nil];
 
-    if ([self.delegate iRateShouldOpenAppStore])
+    // if the delegate has not implemented the method, or if it returns YES
+    if (![self.delegate respondsToSelector:@selector(iRateShouldOpenAppStore)] || [self.delegate iRateShouldOpenAppStore])
     {
         //launch mac app store
         [self openRatingsPageInAppStore];


### PR DESCRIPTION
Declaring these methods as optional and then calling them without testing whether they have been implemented can cause crashes in any delegate class where the methods are not implemented.  

The current workaround in iRate, which declares a category on `NSObject` to prevent these crashes, is invalid as per [the Apple documentation](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html) and can result in undefined behavior:

>If the name of a method declared in a category is the same as a method in the original class, or a method in another category on the same class (or even a superclass), the behavior is undefined as to which method implementation is used at runtime.

This PR does not change any functionality, but will prevent any conditions of undefined behavior.