### PR TITLE
Move to GCD.

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -123,16 +123,18 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 + (void)load
 {
-    [self performSelectorOnMainThread:@selector(sharedInstance) withObject:nil waitUntilDone:NO];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self sharedInstance];
+    });
 }
 
 + (instancetype)sharedInstance
 {
+    static dispatch_once_t once;
     static iRate *sharedInstance = nil;
-    if (sharedInstance == nil)
-    {
+    dispatch_once(&once, ^{
         sharedInstance = [(iRate *)[self alloc] init];
-    }
+    });
     return sharedInstance;
 }
 
@@ -230,7 +232,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 #endif
 
         //app launched
-        [self performSelectorOnMainThread:@selector(applicationLaunched) withObject:nil waitUntilDone:NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self applicationLaunched];
+        });
     }
     return self;
 }
@@ -662,19 +666,15 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 - (void)checkForConnectivityInBackground
 {
-    if ([NSThread isMainThread])
-    {
-        [self performSelectorInBackground:@selector(checkForConnectivityInBackground) withObject:nil];
-        return;
-    }
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
+        [self checkForConnectivity];
+    });
+}
 
+- (void)checkForConnectivity
+{
     @autoreleasepool
     {
-        //prevent concurrent checks
-        static BOOL checking = NO;
-        if (checking) return;
-        checking = YES;
-
         //first check iTunes
         NSString *iTunesServiceURL = [NSString stringWithFormat:iRateAppLookupURLFormat, self.appStoreCountry];
         if (_appStoreID) //important that we check ivar and not getter in case it has changed
@@ -731,7 +731,9 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
                         if (!_appStoreID)
                         {
                             NSString *appStoreIDString = [self valueForKey:@"trackId" inJSON:json];
-                            [self performSelectorOnMainThread:@selector(setAppStoreIDOnMainThread:) withObject:appStoreIDString waitUntilDone:YES];
+                            dispatch_sync(dispatch_get_main_queue(), ^{
+                                [self setAppStoreIDOnMainThread:appStoreIDString];
+                            });
 
                             if (self.verboseLogging)
                             {
@@ -793,16 +795,18 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         //handle errors (ignoring sandbox issues)
         if (error && !(error.code == EPERM && [error.domain isEqualToString:NSPOSIXErrorDomain] && _appStoreID))
         {
-            [self performSelectorOnMainThread:@selector(connectionError:) withObject:error waitUntilDone:YES];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self connectionError:error];
+            });
         }
         else if (self.appStoreID || self.previewMode)
         {
             //show prompt
-            [self performSelectorOnMainThread:@selector(connectionSucceeded) withObject:nil waitUntilDone:YES];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self connectionSucceeded];
+            });
         }
 
-        //finished
-        checking = NO;
     }
 }
 
@@ -991,26 +995,29 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 - (void)didDismissAlert:(__unused id)alertView withButtonAtIndex:(NSInteger)buttonIndex
 {
-    //get button indices
-    NSInteger rateButtonIndex = 0;
-    NSInteger cancelButtonIndex = [self showCancelButton]? 1: 0;
-    NSInteger remindButtonIndex = [self showRemindButton]? cancelButtonIndex + 1: 0;
+    dispatch_async(dispatch_get_main_queue(), ^{
 
-    if (buttonIndex == rateButtonIndex)
-    {
-        [self rate];
-    }
-    else if (buttonIndex == cancelButtonIndex)
-    {
-        [self declineThisVersion];
-    }
-    else if (buttonIndex == remindButtonIndex)
-    {
-        [self remindLater];
-    }
+        //get button indices
+        NSInteger rateButtonIndex = 0;
+        NSInteger cancelButtonIndex = [self showCancelButton]? 1: 0;
+        NSInteger remindButtonIndex = [self showRemindButton]? cancelButtonIndex + 1: 0;
 
-    //release alert
-    self.visibleAlert = nil;
+        if (buttonIndex == rateButtonIndex)
+        {
+            [self rate];
+        }
+        else if (buttonIndex == cancelButtonIndex)
+        {
+            [self declineThisVersion];
+        }
+        else if (buttonIndex == remindButtonIndex)
+        {
+            [self remindLater];
+        }
+        
+        //release alert
+        self.visibleAlert = nil;
+    });
 }
 
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
This patch convert usage of NSThread api to GCD. It simplifies synchronization (because use of queues).
Also it fixes for me errors like this on devices with iOS9:
```
_BSMachError: (os/kern) invalid capability (20)
_BSMachError: (os/kern) invalid name (15)
```
I'am tested this only on ios9 device and on simulators from Xcode7.
I can work to improve it if it will be any comments or suggestions.
Thanks!