### PR TITLE
Facillitate running under a feature flag

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -121,9 +121,10 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 @implementation iRate
 
-+ (void)load
++ (void)initialize
 {
-    [self performSelectorOnMainThread:@selector(sharedInstance) withObject:nil waitUntilDone:NO];
+    if (self == [iRate class])
+        [self performSelectorOnMainThread:@selector(sharedInstance) withObject:nil waitUntilDone:NO];
 }
 
 + (instancetype)sharedInstance


### PR DESCRIPTION
Hi, thanks for the project, it looks great!

I was including this via carthage, and am setting up the ability to enable/disable via a feature flag (ENABLE_APP_RATING), but even if the flag is disabled, the class still goes through the process of initializing the singleton and everything else that comes with that.

This is due to hooking into `+load` which is guaranteed to be called regardless of if the user ever accesses the class. I've changed this to use `+initialize`, which will only run once the user actually calls into the class, and can thus be avoided outright if they so choose.

I did a quick scan to see if there was any particular reason you might have used the former strategy but nothing jumped out. Let me know if I missed something in that regard.
