### PR TITLE
Fix Gibraltar as appStoreCountry

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -189,6 +189,10 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         {
             self.appStoreCountry = @"us";
         }
+        else if ([self.appStoreCountry isEqualToString:@"GI"])
+        {
+            self.appStoreCountry = @"GB";
+        }
 
         //application version (use short version preferentially)
         self.applicationVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];


### PR DESCRIPTION
Check if the country is GI (Gibraltar) to redirect to GB because Gibraltar doesn't have app store country