### PR TITLE
Add Croatian and Bosnian localizations

### DIFF
--- a/iRate/iRate.bundle/bs.lproj/Localizable.strings
+++ b/iRate/iRate.bundle/bs.lproj/Localizable.strings
@@ -1,0 +1,6 @@
+"iRateMessageTitle" = "Ocijeni %@";
+"iRateAppMessage" = "Ako uživate koristeći %@, želite li odvojiti trenutak da date ocjenu? To vam neće uzeti više od minute. Hvala na vašoj podršci!";
+"iRateGameMessage" = "Ako uživate igrati %@, želite li odvojiti trenutak da date ocjenu? To vam neće uzeti više od minute. Hvala na vašoj podršci";
+"iRateCancelButton" = "Ne, hvala";
+"iRateRateButton" = "Ocijeni sada";
+"iRateRemindButton" = "Podsjeti me kasnije";

--- a/iRate/iRate.bundle/hr.lproj/Localizable.strings
+++ b/iRate/iRate.bundle/hr.lproj/Localizable.strings
@@ -1,0 +1,6 @@
+"iRateMessageTitle" = "Ocijeni %@";
+"iRateAppMessage" = "Ako uživate koristeći %@, želite li odvojiti trenutak da date ocjenu? To vam neće uzeti više od minute. Hvala na vašoj podršci!";
+"iRateGameMessage" = "Ako uživate igrati %@, želite li odvojiti trenutak da date ocjenu? To vam neće uzeti više od minute. Hvala na vašoj podršci";
+"iRateCancelButton" = "Ne, hvala";
+"iRateRateButton" = "Ocijeni sada";
+"iRateRemindButton" = "Podsjeti me kasnije";


### PR DESCRIPTION
This PR adds localizations for:
- Croatian (hr)
- Bosnian (bs)

