### PR TITLE
Present a write review form directly

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -85,7 +85,7 @@ static NSString *const iRateMacAppStoreBundleID = @"com.apple.appstore";
 static NSString *const iRateAppLookupURLFormat = @"https://itunes.apple.com/%@/lookup";
 
 static NSString *const iRateiOSAppStoreURLScheme = @"itms-apps";
-static NSString *const iRateiOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@&pageNumber=0&sortOrdering=2&mt=8";
+static NSString *const iRateiOSAppStoreURLFormat = @"https://itunes.apple.com/app/id%@?mt=8&action=write-review";
 static NSString *const iRateiOS7AppStoreURLFormat = @"itms-apps://itunes.apple.com/app/id%@";
 static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.com/app/id%@";
 

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -85,7 +85,7 @@ static NSString *const iRateMacAppStoreBundleID = @"com.apple.appstore";
 static NSString *const iRateAppLookupURLFormat = @"https://itunes.apple.com/%@/lookup";
 
 static NSString *const iRateiOSAppStoreURLScheme = @"itms-apps";
-static NSString *const iRateiOSAppStoreURLFormat = @"https://itunes.apple.com/app/id%@?mt=8&action=write-review";
+static NSString *const iRateiOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/app/id%@?mt=8&action=write-review";
 static NSString *const iRateiOS7AppStoreURLFormat = @"itms-apps://itunes.apple.com/app/id%@";
 static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.com/app/id%@";
 


### PR DESCRIPTION
Apple unveiled parameter to present a write review form directly.

> To automatically open a page on which users can write a review in the App Store, append the query parameter action=write-review to your product URL.

https://developer.apple.com/reference/storekit/skstorereviewcontroller/2851536-requestreview