### PR TITLE
Ignore Carthage Build folder to avoid dirty submodules when using it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ xcuserdata
 Icon?
 ehthumbs.db
 Thumbs.db
+
+# Carthage
+Carthage/Build


### PR DESCRIPTION
Ignore Carthage folder in `.gitignore` file so it won't report as dirty submodule when using Carthage with submodules option