### PR TITLE
Fix for: https://github.com/nicklockwood/iRate/issues/291

### DIFF
--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -699,7 +699,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         NSError *error = nil;
         NSURLResponse *response = nil;
         NSURL *url = [NSURL URLWithString:iTunesServiceURL];
-        NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:REQUEST_TIMEOUT];
+        NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:REQUEST_TIMEOUT];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
We experience app freezing randomly on both devices and simulator (1 in 10 times). 

- How did we find this fix?
Found this fix by debugging and logging stops at `NSLog(@"iRate is checking %@ to retrieve the App Store details...", iTunesServiceURL);`.  We added additional logging and it never made past this line `NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:REQUEST_TIMEOUT];`.

So tried different cachePolicy options and we fond `NSURLRequestReloadIgnoringLocalCacheData` worked well and didn't experience app freezing after.