### PR TITLE
Make the new StoreKitReview compatible with iOS 10.x and Xcode 8.x

### DIFF
--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -54,6 +54,7 @@
 #define IRATE_EXTERN APPKIT_EXTERN
 #endif
 
+#define STOREKIT_REVIEW_AVAILABLE ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_2)
 
 //! Project version number for iRate.
 FOUNDATION_EXPORT double iRateVersionNumber;
@@ -139,7 +140,10 @@ typedef NS_ENUM(NSUInteger, iRateErrorCode)
 @property (nonatomic, copy) NSString *rateButtonLabel;
 
 //debugging and prompt overrides
+#if STOREKIT_REVIEW_AVAILABLE
 @property (nonatomic, assign) BOOL useSKStoreReviewControllerIfAvailable;
+#endif
+
 @property (nonatomic, assign) BOOL useUIAlertControllerIfAvailable;
 @property (nonatomic, assign) BOOL useAllAvailableLanguages;
 @property (nonatomic, assign) BOOL promptForNewVersionIfUserRated;

--- a/iRate/iRate.h
+++ b/iRate/iRate.h
@@ -54,8 +54,6 @@
 #define IRATE_EXTERN APPKIT_EXTERN
 #endif
 
-#define STOREKIT_REVIEW_AVAILABLE ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_2)
-
 //! Project version number for iRate.
 FOUNDATION_EXPORT double iRateVersionNumber;
 
@@ -140,10 +138,8 @@ typedef NS_ENUM(NSUInteger, iRateErrorCode)
 @property (nonatomic, copy) NSString *rateButtonLabel;
 
 //debugging and prompt overrides
-#if STOREKIT_REVIEW_AVAILABLE
-@property (nonatomic, assign) BOOL useSKStoreReviewControllerIfAvailable;
-#endif
 
+@property (nonatomic, assign) BOOL useSKStoreReviewControllerIfAvailable;
 @property (nonatomic, assign) BOOL useUIAlertControllerIfAvailable;
 @property (nonatomic, assign) BOOL useAllAvailableLanguages;
 @property (nonatomic, assign) BOOL promptForNewVersionIfUserRated;

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -39,6 +39,7 @@
 #error This class requires automatic reference counting
 #endif
 
+#define STOREKIT_REVIEW_AVAILABLE ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_10_2)
 
 #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
 #pragma clang diagnostic ignored "-Wobjc-missing-property-synthesis"

--- a/iRate/iRate.m
+++ b/iRate/iRate.m
@@ -200,7 +200,6 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
         //default settings
         self.useAllAvailableLanguages = YES;
-        self.useSKStoreReviewControllerIfAvailable = YES;
         self.promptForNewVersionIfUserRated = NO;
         self.onlyPromptIfLatestVersion = YES;
         self.onlyPromptIfMainWindowIsAvailable = YES;
@@ -213,6 +212,10 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         self.verboseLogging = NO;
         self.previewMode = NO;
 
+#if STOREKIT_REVIEW_AVAILABLE
+        self.useSKStoreReviewControllerIfAvailable = YES;
+#endif
+        
 #if DEBUG
 
         //enable verbose logging in debug mode
@@ -845,11 +848,20 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
 
 #if TARGET_OS_IPHONE
 
-        if (!manual && self.useSKStoreReviewControllerIfAvailable &&
-            [SKStoreReviewController respondsToSelector:@selector(requestReview)])
+        BOOL storeReviewAvailable = NO;
+        
+#if STOREKIT_REVIEW_AVAILABLE
+        storeReviewAvailable = self.useSKStoreReviewControllerIfAvailable;
+#endif
+        
+        if (!manual && storeReviewAvailable)
         {
             [self remindLater];
+            
+#if STOREKIT_REVIEW_AVAILABLE
             [SKStoreReviewController requestReview];
+#endif
+            
         }
         else
         {


### PR DESCRIPTION
Define `STOREKIT_REVIEW_AVAILABLE ` flag to indicate whether `SKStokeReviewController` exists for lower versions of XCode. 
Boolean flag `useSKStoreReviewControllerIfAvailable` is also removed because without `SKStokeReviewController` this is flag is meaningless.