### PR TITLE
mark iRate as deprecated in cocoapods

### DIFF
--- a/iRate.podspec.json
+++ b/iRate.podspec.json
@@ -1,17 +1,18 @@
 {
   "name": "iRate",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "zlib",
   "summary": "A handy class that prompts users of your iPhone or Mac App Store app to rate your application after using it for a while.",
   "homepage": "https://github.com/nicklockwood/iRate",
   "authors": "Nick Lockwood",
   "source": {
     "git": "https://github.com/nicklockwood/iRate.git",
-    "tag": "1.12.1"
+    "tag": "1.12.2"
   },
   "source_files": "iRate/iRate.{h,m}",
   "resources": "iRate/iRate.bundle",
   "requires_arc": true,
+  "deprecated": true,
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"


### PR DESCRIPTION
marking the library as deprecated in the podfile will produce a warning "[!] iRate has been deprecated" after installing irate as dependency. 